### PR TITLE
Restore rsp after function call.

### DIFF
--- a/Kernel/i64int.asm
+++ b/Kernel/i64int.asm
@@ -47,6 +47,7 @@ SECTION .text
 
 %macro LEAVE 0
     POPALL
+    mov     rsp, rbp
     pop     rbp
     ret
 %endmacro

--- a/Userland/libc/crt0.asm
+++ b/Userland/libc/crt0.asm
@@ -43,6 +43,7 @@ EXTERN main
 %endmacro
 
 %macro LEAVE 0
+    mov     rsp, rbp
     pop     rbp
     ret
 %endmacro

--- a/Userland/libc/syscalls.asm
+++ b/Userland/libc/syscalls.asm
@@ -31,6 +31,7 @@ SECTION .text
 
 %macro LEAVE 0
     POPALL
+    mov     rsp, rbp
     pop     rbp
     ret
 %endmacro


### PR DESCRIPTION
I'm surprised the kernel worked at all with this bug...